### PR TITLE
Update K8s 1.19 kube-proxy image to v1.19.6-eksbuild.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+
+- Update K8s 1.19 kube-proxy image to v1.19.6-eksbuild.2 ([#3])
+
 ### Added
 
 - Add support for EKS K8s 1.19 ([#2])
@@ -13,3 +17,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased]: https://github.com/projectsyn/component-eks-addon-manager/compare/463c0761437967d3c90416a8c86e9c85e29e8fc6...HEAD
 [#1]: https://github.com/projectsyn/component-eks-addon-manager/pull/1
 [#2]: https://github.com/projectsyn/component-eks-addon-manager/pull/2
+[#3]: https://github.com/projectsyn/component-eks-addon-manager/pull/3

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -36,7 +36,7 @@ parameters:
         '1.18':
           tag: 'v1.18.8-eksbuild.1'
         '1.19':
-          tag: 'v1.19.6-eksbuild.1'
+          tag: 'v1.19.6-eksbuild.2'
       aws-k8s-cni:
         '1.17':
           tag: 'v1.7.5'


### PR DESCRIPTION
AWS recommends using v1.19.6-eksbuild.2 instead of v1.19.6-eksbuild.1

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.
